### PR TITLE
Add comment hotkey support

### DIFF
--- a/Counter Strike Global Offensive.tmPreferences
+++ b/Counter Strike Global Offensive.tmPreferences
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+   <dict>
+      <key>scope</key>
+      <string>source.csgo</string>
+      <key>settings</key>
+      <dict>
+         <key>shellVariables</key>
+         <array>
+            <dict>
+               <key>name</key>
+               <string>TM_COMMENT_START</string>
+               <key>value</key>
+               <string>// </string>
+            </dict>
+         </array>
+      </dict>
+   </dict>
+</plist>


### PR DESCRIPTION
I find it useful to be able to use `ctrl+/` to comment/uncomment code blocks, so I've added this ability to csgo config files.

I've only tested this on my local machine using Sublime Text build 3126 but it should work on any version of ST2 or ST3.